### PR TITLE
Simplify library/books.json

### DIFF
--- a/library/books.json
+++ b/library/books.json
@@ -1,45 +1,36 @@
 {
     "books": {
-        "PR6039.O32": [{
-                "H63": {
-                    "title": "The Hobbit",
-                    "author": "J. R. R. Tolkien",
-                    "published": "21 September 1937",
-                    "genre": "Fantasy",
-                    "class": "PR6039.O32 H63",
-                    "in-stock": false
-                }
-            },
-            {
-                "L67": {
-                    "title": "The Fellowship of the Ring",
-                    "author": "J. R. R. Tolkien",
-                    "published": "29 July 1954",
-                    "genre": "Fantasy",
-                    "class": "PR6039.O32 L67",
-                    "in-stock": true
-                }
-            },
-            {
-                "L68": {
-                    "title": "The Two Towers",
-                    "author": "J. R. R. Tolkien",
-                    "published": "11 November 1954",
-                    "genre": "Fantasy",
-                    "class": "PR6039.O32 L68",
-                    "in-stock": true
-                }
-            },
-            {
-                "L69": {
-                    "title": "The Return of the King",
-                    "author": "J. R. R. Tolkien",
-                    "published": "21 September 1937",
-                    "genre": "Fantasy",
-                    "class": "PR6039.O32 L69",
-                    "in-stock": true
-                }
-            }
-        ]
+        "H63": {
+            "title": "The Hobbit",
+            "author": "J. R. R. Tolkien",
+            "published": "21 September 1937",
+            "genre": "Fantasy",
+            "class": "PR6039.O32 H63",
+            "in-stock": false
+        },
+        "L67": {
+            "title": "The Fellowship of the Ring",
+            "author": "J. R. R. Tolkien",
+            "published": "29 July 1954",
+            "genre": "Fantasy",
+            "class": "PR6039.O32 L67",
+            "in-stock": true
+        },
+        "L68": {
+            "title": "The Two Towers",
+            "author": "J. R. R. Tolkien",
+            "published": "11 November 1954",
+            "genre": "Fantasy",
+            "class": "PR6039.O32 L68",
+            "in-stock": true
+        },
+        "L69": {
+            "title": "The Return of the King",
+            "author": "J. R. R. Tolkien",
+            "published": "21 September 1937",
+            "genre": "Fantasy",
+            "class": "PR6039.O32 L69",
+            "in-stock": true
+        }
     }
 }


### PR DESCRIPTION
Why:
----

I think the data structure in library/books.json is significantly more
complex than the other benchmark data structures. I think this causes
the benchmark to be less informative due to the lack of consistency.

How Is It More Complex:
-----------------------

All of the other benchmark data structures have a shape that looks like
this:

    collection of <item> collections

- coffee_shop      : list of <coffee> dictionaries
- dog_store        : list of <product> dictionaries (or lists)
- donut_shop       : lists of <choice> strings
- grocery_store    : meaningfully the same as dog_store
- movie_theater    : dictionary of <movie> dictionaries

This means that the students will generally search for an item in one
of two ways:

    for item in collection:
        ...

or

    collection[key]

For the library benchmark, the data structure is a

    dictionary of lists of dictionaries of <book> dictionaries

If the student isn't allowed to assume anything other than the natural
shape of the data structures (i.e. dictionaries have many key-value
pairs, lists have many elements) this means that to find a book the student
will have to do something like this:

    for list_of_inner_dictionaries in collection.values():
        for inner_dictionary in list_of_inner_dictionaries:
            for book in inner_dictionary.values():
                ...

I think this is particularly challenging because the two outer layers
don't meaningfully inform any of the application features demanded by
the benchmark project. I may be incorrect in that, but I couldn't see
the impact. I mostly worked to ignore those outer layers when building
a solution for myself.

How This Simplifies It:
-----------------------

This commit simplifies the data structure to be a

    dictionary of <book> dictionaries

This puts the data structure in line with the complexity level of the
other benchmark projects without sacrificing any application level
concerns for the project.